### PR TITLE
Fix: shortcut stuck state

### DIFF
--- a/apps/desktop/src/components/user-dropdown.tsx
+++ b/apps/desktop/src/components/user-dropdown.tsx
@@ -24,6 +24,19 @@ import { DictoLogo } from "@/components/dicto-logo";
 export function UserDropdown() {
 	const session = authClient.useSession();
 	const [showAuthDialog, setShowAuthDialog] = useState(false);
+	const [authStep, setAuthStep] = useState<"credentials" | "otp">("credentials");
+
+	// Handle dialog close - prevent closing during OTP step
+	const handleDialogChange = (open: boolean) => {
+		if (!open && authStep === "otp") {
+			// Don't close if in OTP step
+			return;
+		}
+		setShowAuthDialog(open);
+		if (!open) {
+			setAuthStep("credentials");
+		}
+	};
 
 	if (session.isPending) {
 		return <Skeleton className="size-8 rounded-sm border border-gray-300" />;
@@ -42,7 +55,7 @@ export function UserDropdown() {
 					Login
 				</Button>
 
-				<Dialog open={showAuthDialog} onOpenChange={setShowAuthDialog}>
+				<Dialog open={showAuthDialog} onOpenChange={handleDialogChange}>
 					<DialogContent className="max-w-md bg-white">
 						<DialogHeader>
 							<div className="mx-auto mb-2">
@@ -55,7 +68,7 @@ export function UserDropdown() {
 								Sign in to unlock cloud mode and smart features
 							</p>
 						</DialogHeader>
-						<EmailSignIn />
+						<EmailSignIn onStepChange={setAuthStep} />
 					</DialogContent>
 				</Dialog>
 			</>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents the global shortcut from getting stuck by auto-resetting after 5 seconds, and cleans up the email OTP flow with correct verification and auto sign-in. Also prevents the auth dialog from closing during the OTP step.

- **Bug Fixes**
  - Shortcut: add 5s timeout with activated_at tracking; auto-reset state and clear on change/unregister to avoid stuck FN key.
  - Auth: use emailOtp.verifyEmail, remove duplicate OTP send on sign-up, store password to auto sign in after verification, set token, and handle fallback on failure.
  - UX: EmailSignIn exposes onStepChange; user dropdown blocks dialog close during OTP and resets step on close.

<sup>Written for commit 78a750db0228d4ffc45a694ee8a18ad1134df810. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented OTP-based email verification flow during sign-in.
  * Added auto sign-in following successful OTP verification.
  * Enhanced dialog with OTP-aware flow that prevents accidental closure during verification.

* **Bug Fixes**
  * Fixed potential global shortcut stuck state with automatic timeout-based reset.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->